### PR TITLE
Enable world config

### DIFF
--- a/src/main/java/whackamole/whackamole/Commands.java
+++ b/src/main/java/whackamole/whackamole/Commands.java
@@ -80,6 +80,10 @@ public class Commands {
                         )
                         .executesPlayer((player, args) -> {
                             try {
+                                if (Config.Game.ENABLED_WOLRDS.size() > 1 && !Config.Game.ENABLED_WOLRDS.contains(player.getWorld())) {
+                                    player.sendMessage("Unable to create the game because this world in not enabled in the config\nPlease update the config to enable game creation in this world.");
+                                    return;
+                                }
                                 String gameName = (String) args.get(0);
                                 this.manager.addGame(gameName, Grid.searchGrid(player.getWorld(), player), player);
                                 player.sendMessage(Config.AppConfig.PREFIX + Translator.COMMANDS_CREATE_SUCCESS.Format());

--- a/src/main/java/whackamole/whackamole/Config.java
+++ b/src/main/java/whackamole/whackamole/Config.java
@@ -52,6 +52,7 @@ public class Config {
     public static class Game {
         public static String ACTIONTEXT, HAMMERNAME = "Hammer", HAMMER_ITEM;
         public static boolean ENABLE_GAMECONFIG;
+        public static List<?> ENABLED_WOLRDS;
 
         public static int FIELD_MAX_SIZE, HAMMER_CUSTOMMODELDATA, HAMMER_ITEMDAMAGE;
         public static Double FiELD_MARGIN_X, FiELD_MARGIN_Y;
@@ -74,6 +75,7 @@ public class Config {
             FiELD_MARGIN_Y          = configFile.getDouble("Field extension.height");
 
             ENABLE_GAMECONFIG       = configFile.getBoolean("Game config");
+            ENABLED_WOLRDS          = configFile.getList("Enabled worlds");
             HITSOUND                = configFile.getSound("HitSound");
             MISSSOUND               = configFile.getSound("MissedSound");
 

--- a/src/main/java/whackamole/whackamole/GamesManager.java
+++ b/src/main/java/whackamole/whackamole/GamesManager.java
@@ -86,7 +86,7 @@ public final class GamesManager implements Listener {
                 }
 
                 if (world == null || yWorld.equals(world.getName())) {
-                    if(Config.Game.ENABLED_WOLRDS.size() > 1 && Config.Game.ENABLED_WOLRDS.contains(yWorld)) {
+                    if(Config.Game.ENABLED_WOLRDS.size() > 1 && ! Config.Game.ENABLED_WOLRDS.contains(yWorld)) {
                         Logger.warning(String.format("Skipping game file %s since the world %s is not enabled in the config", i.getName(), yWorld));
                         continue file_loop;
                     }
@@ -101,7 +101,7 @@ public final class GamesManager implements Listener {
         }
         
         for(var game : DBGameList) {
-            if(Config.Game.ENABLED_WOLRDS.size() > 1 && Config.Game.ENABLED_WOLRDS.contains(game.worldName)) {
+            if(Config.Game.ENABLED_WOLRDS.size() > 1 && ! Config.Game.ENABLED_WOLRDS.contains(game.worldName)) {
                 Logger.warning(String.format("Skipping game %s since the world %s is not enabled in the config", game.Name, game.worldName));
                 continue;
             }
@@ -179,7 +179,7 @@ public final class GamesManager implements Listener {
     }
     @EventHandler
     public void onWorldLoad(WorldLoadEvent e) {
-        if (Config.Game.ENABLED_WOLRDS.size() > 1 && Config.Game.ENABLED_WOLRDS.contains(e.getWorld())) {
+        if (Config.Game.ENABLED_WOLRDS.size() > 1 && ! Config.Game.ENABLED_WOLRDS.contains(e.getWorld())) {
             return;
         }
         Logger.info(Translator.MANAGER_LOADINGGAMES.Format(e.getWorld().getName()));

--- a/src/main/java/whackamole/whackamole/GamesManager.java
+++ b/src/main/java/whackamole/whackamole/GamesManager.java
@@ -86,6 +86,10 @@ public final class GamesManager implements Listener {
                 }
 
                 if (world == null || yWorld.equals(world.getName())) {
+                    if(Config.Game.ENABLED_WOLRDS.size() > 1 && Config.Game.ENABLED_WOLRDS.contains(yWorld)) {
+                        Logger.warning(String.format("Skipping game file %s since the world %s is not enabled in the config", i.getName(), yWorld));
+                        continue file_loop;
+                    }
                     for (var game : DBGameList) {
                         if(game.ID == yID) {
                             continue file_loop;
@@ -97,6 +101,10 @@ public final class GamesManager implements Listener {
         }
         
         for(var game : DBGameList) {
+            if(Config.Game.ENABLED_WOLRDS.size() > 1 && Config.Game.ENABLED_WOLRDS.contains(game.worldName)) {
+                Logger.warning(String.format("Skipping game %s since the world %s is not enabled in the config", game.Name, game.worldName));
+                continue;
+            }
             this.games.add(new Game(game));
         }
         for(var game : fileGameList) {
@@ -171,6 +179,9 @@ public final class GamesManager implements Listener {
     }
     @EventHandler
     public void onWorldLoad(WorldLoadEvent e) {
+        if (Config.Game.ENABLED_WOLRDS.size() > 1 && Config.Game.ENABLED_WOLRDS.contains(e.getWorld())) {
+            return;
+        }
         Logger.info(Translator.MANAGER_LOADINGGAMES.Format(e.getWorld().getName()));
         if (!this.GameLoading(e.getWorld())) {
             Logger.warning(Translator.MANAGER_NOGAMESFOUND);
@@ -268,6 +279,5 @@ public final class GamesManager implements Listener {
             player.sendMessage(Config.AppConfig.PREFIX + Translator.MANAGER_TICKETUSE_GAMENOTFOUND);
             e.setCancelled(true);
         });
-
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,7 +4,7 @@
 # <------------------------------------------------------> #
 ############################################################
 
-Config Version: 1.7
+Config Version: 1.8
 
 # Welcome to the config file, here you can adjust the general settings of the plugin.
 # the lines must be in YAML format, so it doesn't accept tabs, only spaces.
@@ -85,6 +85,10 @@ Ticket Price: 15
 # Game data is stored in a SQL database, optionally you can choose to generate a config file for each WAM game.
 # Having the config file allows you to make multiple changes in one go, if this is disabled, game settings can only be changed and seen by commands (/wam settings).
 Game config: true
+
+
+# The list of worlds Whackamole should interact with. If this list is empty then all worlds are enabled. 
+Enabled worlds:
 
 # For sounds, please refer to the Sound enum to see the Java equivalent of the minecraft sound: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Sound.html.
 # What sound should be played when a mole has been hit.


### PR DESCRIPTION
Added config option to limit the worlds where Whackamole works.

### Added an option in the Config.yml

```yml
# The list of worlds Whackamole should interact with. If this list is empty then all worlds are enabled. 
Enabled worlds:
---
# limited example
Enabled worlds:
  - nether
```
___

 - Translations needed
   - [Game File loading](https://github.com/CraZyRc/WhackaMole/blob/dbdcf7cb36b28e02f3b13b319ad7ee027ea1f63e/src/main/java/whackamole/whackamole/GamesManager.java#L90) warning message for already existing game files which are now disabled.
   - [DB Game file loading](https://github.com/CraZyRc/WhackaMole/blob/dbdcf7cb36b28e02f3b13b319ad7ee027ea1f63e/src/main/java/whackamole/whackamole/GamesManager.java#L105) warning for now disabled games.
   - [Game creation failure](https://github.com/CraZyRc/WhackaMole/blob/dbdcf7cb36b28e02f3b13b319ad7ee027ea1f63e/src/main/java/whackamole/whackamole/Commands.java#L84) message when user wants to create a game in an not enabled world.

